### PR TITLE
fix bugs in returned ligand atoms by adsorbate_pre.py

### DIFF
--- a/catlearn/featurize/adsorbate_prep.py
+++ b/catlearn/featurize/adsorbate_prep.py
@@ -539,6 +539,7 @@ def info2primary_index(atoms):
         for a_s in slab_atoms:
             if cm[a_s, j] > 0:
                 ligand.append(a_s)
+    ligand = [lig for lig in list(np.unique(ligand)) if lig not in site]
     if len(chemi) is 0 or len(site) is 0:
         print(chemi, site, ligand)
         msg = 'No adsorption site detected.'


### PR DESCRIPTION
In the adsorbate_pre.py , at line 511, the function ' info2primary_index(atoms)' produces repeated ligand atoms. Besides, if an adsorbate is at a bridge site or a hollow site, the returned ligand atoms will include site atoms. To fix these two bugs, a line " ligand = [lig for lig in list(np.unique(ligand)) if lig not in site] " is inserted at line 542.