### PR TITLE
fix bug in site_atoms in adsorbate_prep.py

### DIFF
--- a/catlearn/featurize/adsorbate_prep.py
+++ b/catlearn/featurize/adsorbate_prep.py
@@ -534,7 +534,9 @@ def info2primary_index(atoms):
                 site.append(a_s)
                 chemi.append(a_a)
     chemi = list(np.unique(chemi))
-    site = list(np.unique(site))
+   # site = list(np.unique(site))
+    termination_atoms = detect_termination(atoms)[1]
+    site = [sit for sit in list(np.unique(site)) if sit in termination_atoms]
     for j in site:
         for a_s in slab_atoms:
             if cm[a_s, j] > 0:


### PR DESCRIPTION
At line 537 in adsorbate_prep.py,  the site atoms should be a subset of termination atoms. So,  two lines,  " termination_atoms = detect_termination(atoms)[1] " and "site = [sit for sit in list(np.unique(site)) if sit in termination_atoms]", are inserted at line 538 and 539, respectively. Before fixing this bug, for the ase builded atoms, i.e.,   atoms_1 = fcc111('Pd', size=(2, 2, 3), vacuum=10.0) add_adsorbate(atoms_1, 'C', 1, 'hcp') , the autogen returned site_atoms include the subsurface atoms_1[5], i.e., site_atoms=[5, 9, 10, 11], but actually the site_atoms =[9, 10, 11]