### PR TITLE
bugfix

### DIFF
--- a/catlearn/api/ase_atoms_api.py
+++ b/catlearn/api/ase_atoms_api.py
@@ -47,7 +47,7 @@ def images_connectivity(images, check_cn_max=False):
     for atoms in tqdm(images):
         if not hasattr(atoms, 'connectivity'):
             radii = [default_catlearn_radius(z) for z in atoms.numbers]
-            atoms.connectivity = ase_connectivity(atoms, radii)
+            atoms.connectivity = ase_connectivity(atoms, cutoffs=radii)
             if check_cn_max:
                 n_connections = np.sum(atoms.connectivity, axis=0)
                 if max(n_connections) > 12:

--- a/catlearn/utilities/neighborlist.py
+++ b/catlearn/utilities/neighborlist.py
@@ -164,9 +164,9 @@ def ase_connectivity(atoms, cutoffs=None, count_bonds=True):
     if hasattr(atoms, 'neighborlist'):
         nl = atoms.neighborlist
     else:
-        nl = NeighborList(cutoffs=cutoffs, bothways=True)
+        nl = NeighborList(cutoffs=cutoffs, skin=0, bothways=True,
+                          self_interaction=False)
         nl.update(atoms)
         conn_mat = nl.get_connectivity_matrix(sparse=False)
-        np.fill_diagonal(conn_mat, 0)
 
     return np.asarray(conn_mat, dtype=int)

--- a/test/test_autocorrelation.py
+++ b/test/test_autocorrelation.py
@@ -17,7 +17,7 @@ class TestAutoCorrelation(unittest.TestCase):
         """Test the feature generation."""
         atoms = molecule('HCOOH')
         atoms.center(vacuum=5)
-        radii = [covalent_radii[z] for z in atoms.numbers]
+        radii = [covalent_radii[z] + 0.1 for z in atoms.numbers]
         atoms.connectivity = ase_connectivity(atoms, radii)
         images = [atoms]
         gen = FeatureGenerator()

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -94,4 +94,3 @@ if __name__ == '__main__':
     os.remove('results_neb_interpolation.csv')
     os.remove('ML-NEB.traj')
     os.remove('warnings_and_errors.txt')
-


### PR DESCRIPTION
ase neighborlist uses a default skin parameter of 0.3 aangtrom, which causes extra neighbors to be identified. This fix sets the skin to 0.