### PR TITLE
fhi-aims compatibility

### DIFF
--- a/catlearn/optimize/mlneb.py
+++ b/catlearn/optimize/mlneb.py
@@ -14,6 +14,7 @@ from catlearn.regression import GaussianProcess
 from ase.calculators.calculator import Calculator, all_changes
 from ase.atoms import Atoms
 from catlearn import __version__
+import copy
 
 
 class MLNEB(object):
@@ -862,7 +863,7 @@ def get_energy_catlearn(self, x=None):
 
     self.ase_ini.set_calculator(None)
     self.ase_ini = Atoms(self.ase_ini, positions=pos_ase,
-                         calculator=self.ase_calc)
+                         calculator=copy.deepcopy(self.ase_calc))
     energy = self.ase_ini.get_potential_energy(force_consistent=self.fc)
     return energy
 

--- a/catlearn/optimize/mlneb.py
+++ b/catlearn/optimize/mlneb.py
@@ -14,7 +14,6 @@ from catlearn.regression import GaussianProcess
 from ase.calculators.calculator import Calculator, all_changes
 from ase.atoms import Atoms
 from catlearn import __version__
-import copy
 
 
 class MLNEB(object):
@@ -863,7 +862,7 @@ def get_energy_catlearn(self, x=None):
 
     self.ase_ini.set_calculator(None)
     self.ase_ini = Atoms(self.ase_ini, positions=pos_ase,
-                         calculator=copy.deepcopy(self.ase_calc))
+                         calculator=self.ase_calc)
     energy = self.ase_ini.get_potential_energy(force_consistent=self.fc)
     return energy
 
@@ -916,7 +915,10 @@ def eval_and_append(self, interesting_point):
 
     self.list_train = np.append(self.list_train,
                                 interesting_point, axis=0)
-
+    
+    # Remove old calculation information 
+    self.ase_calc.results = {}
+    
     energy = get_energy_catlearn(self)
 
     self.list_targets = np.append(self.list_targets, energy)


### PR DESCRIPTION
FHI-aims calculator check_state is not behaving as it should, preventing the calculations from occurring after the first one. 

Erasing results prior to next calculation  restores intended functionality in ASE/FHI-aims/MLNEB setup. 

Change does not affect performance based on mlneb.py test.