### PR TITLE
Update get number of atoms function

### DIFF
--- a/catlearn/optimize/mlmin.py
+++ b/catlearn/optimize/mlmin.py
@@ -73,7 +73,7 @@ class MLMin(object):
         assert self.ase_calc, msg
         self.constraints = self.ase_ini.constraints
         self.x0 = self.ase_ini.get_positions().flatten()
-        self.num_atoms = self.ase_ini.get_number_of_atoms()
+        self.num_atoms = self.ase_ini.get_global_number_of_atoms()
 
         # Information from the initial structure.
         new_atoms = self.ase_ini


### PR DESCRIPTION
In Ase 3.22, get_number_of_atoms() is deprecated.
It is suggested, "if your atoms are distributed, use (and see) get_global_number_of_atoms()."